### PR TITLE
Add option to evaluate only on terminal messages

### DIFF
--- a/browsergym/core/src/browsergym/core/env.py
+++ b/browsergym/core/src/browsergym/core/env.py
@@ -129,7 +129,7 @@ class BrowserEnv(gym.Env, ABC):
         self.connect_via_cdp = connect_via_cdp
         self.cdp_port = cdp_port
         self.evaluate_reward_on_terminal_msgs = evaluate_reward_on_terminal_msgs
-
+        self.terminal_message_received  = False
         # check argument values
         assert tags_to_mark in ("all", "standard_html")
 
@@ -477,23 +477,23 @@ document.addEventListener("visibilitychange", () => {
         logger.debug(f"Initiating task validation")
         # extract reward, done, user_message, info (task-specific)
 
-       
-        
         if self.evaluate_reward_on_terminal_msgs:
-            if not self.terminal_message_received:
+            if self.terminal_message_received:
                 reward, done, user_message, task_info = self._task_validate()
                 info["task_info"] = task_info
                 logger.debug(f"Task validation done")
+                done = True
             else:
+                reward = 0
                 done = False
         else:
             reward, done, user_message, task_info = self._task_validate()
             info["task_info"] = task_info
             logger.debug(f"Task validation done")
 
-        # add any user message sent by the task to the chat
-        if user_message:
-            self.chat.add_message(role="user", msg=user_message)
+            # add any user message sent by the task to the chat
+            if user_message:
+                self.chat.add_message(role="user", msg=user_message)
 
         # extract observation (generic)
         obs = self._get_obs()

--- a/browsergym/core/src/browsergym/core/env.py
+++ b/browsergym/core/src/browsergym/core/env.py
@@ -482,7 +482,6 @@ document.addEventListener("visibilitychange", () => {
                 reward, done, user_message, task_info = self._task_validate()
                 info["task_info"] = task_info
                 logger.debug(f"Task validation done")
-                done = True
             else:
                 reward = 0
                 done = False

--- a/browsergym/core/src/browsergym/core/env.py
+++ b/browsergym/core/src/browsergym/core/env.py
@@ -477,15 +477,7 @@ document.addEventListener("visibilitychange", () => {
         logger.debug(f"Initiating task validation")
         # extract reward, done, user_message, info (task-specific)
 
-        if self.evaluate_reward_on_terminal_msgs:
-            if self.terminal_message_received:
-                reward, done, user_message, task_info = self._task_validate()
-                info["task_info"] = task_info
-                logger.debug(f"Task validation done")
-            else:
-                reward = 0
-                done = False
-        else:
+        if not self.evaluate_reward_on_terminal_msgs or (self.evaluate_reward_on_terminal_msgs and self.terminal_message_received):
             reward, done, user_message, task_info = self._task_validate()
             info["task_info"] = task_info
             logger.debug(f"Task validation done")
@@ -494,6 +486,10 @@ document.addEventListener("visibilitychange", () => {
             if user_message:
                 self.chat.add_message(role="user", msg=user_message)
 
+        else:
+            reward = 0
+            done = False
+      
         # extract observation (generic)
         obs = self._get_obs()
         logger.debug(f"Observation extracted")

--- a/browsergym/core/src/browsergym/core/env.py
+++ b/browsergym/core/src/browsergym/core/env.py
@@ -80,6 +80,7 @@ class BrowserEnv(gym.Env, ABC):
         init_script: Optional[str] = None,
         connect_via_cdp: bool = False,
         cdp_port: int = 0,
+        evaluate_reward_on_terminal_msgs: bool = False,
     ):
         """
         Instantiate a ready to use BrowserEnv gym environment.
@@ -102,6 +103,8 @@ class BrowserEnv(gym.Env, ABC):
             action_mapping: if set, the environment will use this function to map every received action to executable Python code.
             extra_obs_func: if set, this function will be called between actions to get observations.
             init_script: if set, this JavaScript code will be executed in every frame.
+            evaluate_reward_on_terminal_msgs: boolean to determine whether the evaluator should be run on every step or only when the agent finds
+            a send_msg_to_user or a report_infeasibility message.
 
         """
         super().__init__()
@@ -125,6 +128,7 @@ class BrowserEnv(gym.Env, ABC):
         self.init_script = init_script
         self.connect_via_cdp = connect_via_cdp
         self.cdp_port = cdp_port
+        self.evaluate_reward_on_terminal_msgs = evaluate_reward_on_terminal_msgs
 
         # check argument values
         assert tags_to_mark in ("all", "standard_html")
@@ -423,12 +427,14 @@ document.addEventListener("visibilitychange", () => {
             if not isinstance(text, str):
                 raise ValueError(f"Forbidden value: {text} is not a string")
             self.chat.add_message(role="assistant", msg=text)
+            self.terminal_message_received = True
 
         def report_infeasible_instructions(reason: str):
             if not isinstance(reason, str):
                 raise ValueError(f"Forbidden value: {reason} is not a string")
             self.chat.add_message(role="infeasible", msg=reason)
             self.infeasible_message_received = True
+            self.terminal_message_received = True
 
         # try to execute the action
         logger.debug(f"Executing action")
@@ -470,9 +476,20 @@ document.addEventListener("visibilitychange", () => {
 
         logger.debug(f"Initiating task validation")
         # extract reward, done, user_message, info (task-specific)
-        reward, done, user_message, task_info = self._task_validate()
-        info["task_info"] = task_info
-        logger.debug(f"Task validation done")
+
+       
+        
+        if self.evaluate_reward_on_terminal_msgs:
+            if not self.terminal_message_received:
+                reward, done, user_message, task_info = self._task_validate()
+                info["task_info"] = task_info
+                logger.debug(f"Task validation done")
+            else:
+                done = False
+        else:
+            reward, done, user_message, task_info = self._task_validate()
+            info["task_info"] = task_info
+            logger.debug(f"Task validation done")
 
         # add any user message sent by the task to the chat
         if user_message:

--- a/browsergym/subtaskbench/src/browsergym/subtaskbench/task.py
+++ b/browsergym/subtaskbench/src/browsergym/subtaskbench/task.py
@@ -79,6 +79,7 @@ class GenericSubTaskBenchTask(AbstractBrowserTask):
             logger.info(answer)
             terminal_message_received = True
         elif chat_messages and chat_messages[-1]["role"] == "infeasible":
+            answer = chat_messages[-1]["message"]
             terminal_message_received = True
         else:
             answer = ""

--- a/browsergym/subtaskbench/src/browsergym/subtaskbench/task.py
+++ b/browsergym/subtaskbench/src/browsergym/subtaskbench/task.py
@@ -73,9 +73,13 @@ class GenericSubTaskBenchTask(AbstractBrowserTask):
             info: dictionnary, custom information from the task.
 
         """
+        terminal_message_received = False
         if chat_messages and chat_messages[-1]["role"] == "assistant":
             answer = chat_messages[-1]["message"]
             logger.info(answer)
+            terminal_message_received = True
+        elif chat_messages and chat_messages[-1]["role"] == "infeasible":
+            terminal_message_received = True
         else:
             answer = ""
 
@@ -83,7 +87,7 @@ class GenericSubTaskBenchTask(AbstractBrowserTask):
         logger.info(f"Reward: {reward}")
         done = math.isclose(reward, 1.0, abs_tol=1e-5)
 
-        return reward, done, "", {}
+        return reward, terminal_message_received, "", {}
 
 
 class StaticSubTaskBenchTask(GenericSubTaskBenchTask):

--- a/browsergym/subtaskbench/src/browsergym/subtaskbench/task.py
+++ b/browsergym/subtaskbench/src/browsergym/subtaskbench/task.py
@@ -86,7 +86,6 @@ class GenericSubTaskBenchTask(AbstractBrowserTask):
 
         reward = self.evaluator.evaluate(answer, page)
         logger.info(f"Reward: {reward}")
-        done = math.isclose(reward, 1.0, abs_tol=1e-5)
 
         return reward, terminal_message_received, "", {}
 


### PR DESCRIPTION
Example traces: https://vis.orbyapi.com/runs/?path=s3%3A//orby-llm/browsergym_eval/test-zmR92e_2025-05-05_19-34-24/subtaskbench_hsm_v3_claude_claude
note: online.44 is outputting a bad string so it is not parsed as a valid terminal message